### PR TITLE
Add OpenSearch Descriptor for Manga Search

### DIFF
--- a/anilist-manga-search.xml
+++ b/anilist-manga-search.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription
+  xmlns="http://a9.com/-/spec/opensearch/1.1/"
+  xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>AniList Manga Search</ShortName>
+  <Description>Allows one to search Anilist's Mangas</Description>
+  <Developer>https://github.com/master-bob</Developer>
+  <Attribution>Search data from AniList, LLC</Attribution>
+  <AdultContent>true</AdultContent>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image type="image/svg+xml">/img/logo.svg</Image>
+  <Url type="text/html" method="get" template="https://anilist.co/search/manga?sort=SEARCH_MATCH&search={searchTerms}"/>
+  <Url type="application/opensearchdescription+xml" rel="self" template="anilist-manga-search.xml" />
+</OpenSearchDescription>

--- a/anilist-manga-search.xml
+++ b/anilist-manga-search.xml
@@ -10,5 +10,5 @@
   <InputEncoding>UTF-8</InputEncoding>
   <Attribution>Search data from AniList, LLC</Attribution>
   <AdultContent>true</AdultContent>
-  <Url type="application/opensearchdescription+xml" rel="self" template="https://master-bob.github.io/al-search/anilist-manga-search.xml" />
+  <Url type="application/opensearchdescription+xml" rel="self" template="https://yellowfish085.github.io/al-search/anilist-manga-search.xml" />
 </OpenSearchDescription>

--- a/anilist-manga-search.xml
+++ b/anilist-manga-search.xml
@@ -4,11 +4,11 @@
   xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <ShortName>AniList Manga Search</ShortName>
   <Description>Allows one to search Anilist's Mangas</Description>
+  <Url type="text/html" method="get" template="https://anilist.co/search/manga?search={searchTerms}" />
+  <Image type="image/svg+xml">/img/logo.svg</Image>
   <Developer>https://github.com/master-bob</Developer>
+  <InputEncoding>UTF-8</InputEncoding>
   <Attribution>Search data from AniList, LLC</Attribution>
   <AdultContent>true</AdultContent>
-  <InputEncoding>UTF-8</InputEncoding>
-  <Image type="image/svg+xml">/img/logo.svg</Image>
-  <Url type="text/html" method="get" template="https://anilist.co/search/manga?sort=SEARCH_MATCH&search={searchTerms}"/>
-  <Url type="application/opensearchdescription+xml" rel="self" template="anilist-manga-search.xml" />
+  <Url type="application/opensearchdescription+xml" rel="self" template="https://master-bob.github.io/al-search/anilist-manga-search.xml" />
 </OpenSearchDescription>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
     <link href="img/logo.svg" rel="icon" type="image/svg+xml">
     <link href="vendor/fontawesome/css/all.min.css" rel="stylesheet">
     <link href="assets/style.css" rel="stylesheet">
+    <link rel="search"
+	  type="application/opensearchdescription+xml"
+	  title="AniList Manga Search"
+	  href="/anilist-manga-search.xml" />
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -149,6 +149,7 @@
 
             <p>It is impossible to define multiple search providers per extension, and it is impossible to have multiple search urls for a single search provider. Since <b>AniList</b> does not have a global search page, the extension can only add one search provider limited to one type of data.</p>
             <p>Anime was choosen because it is the main data on the website.</p>
+	    <p>However a workaround is available. To use this please right click on the address bar and then select <b>Add "AniList Manga Search"</b>.</p>
         </div>
 
         <div class="card">

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="search"
 	  type="application/opensearchdescription+xml"
 	  title="AniList Manga Search"
-	  href="/anilist-manga-search.xml" />
+	  href="./anilist-manga-search.xml" />
 </head>
 
 <body>


### PR DESCRIPTION
This adds the ability for a user to add a dedicated manga search provider to OpenSearch Descriptor browsers, like Firefox.

A brief how to is added to the dedicated page.  And probably also allows for the manga search to be added to Chrome.

I'm not sure, but this might also work with Chrome as well. it has only been tested on Firefox 128.14.0esr (64-bit).